### PR TITLE
helm chart volume logs and idx type fix

### DIFF
--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -293,9 +293,9 @@ volume:
 
   # same applies to "logs"
 
-  idx: ""
+  idx: {}
 
-  logs: ""
+  logs: {}
 
   # limit background compaction or copying speed in mega bytes per second
   compactionMBps: "50"


### PR DESCRIPTION
# What problem are we solving?
`values.yaml` contains incorrect empty values for `volume.logs` and `volume.idx`


# How are we solving the problem?
These are maps and so the default empty values have been set to `{}`


# How is the PR tested?
Desk checked.


# Checks
- [na ] I have added unit tests if possible.
- [ na] I will add related wiki document changes and link to this PR after merging.
