### PR TITLE
Helm chart: make s3 ingress annotations consistent

### DIFF
--- a/k8s/charts/seaweedfs/templates/s3-ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-ingress.yaml
@@ -10,9 +10,9 @@ kind: Ingress
 metadata:
   name: ingress-{{ template "seaweedfs.name" . }}-s3
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.s3.ingress.annotations }}
+  {{- if .Values.s3.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl .Values.s3.ingress.annotations . | nindent 4 }}
   {{- end }}
   labels:
     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -746,7 +746,7 @@ s3:
     # host: false for "*" hostname
     host: "seaweedfs.cluster.local"
     # additional ingress annotations for the s3 endpoint
-    annotations: []
+    annotations: ""
     tls: []
 
 certificates:


### PR DESCRIPTION
# What problem are we solving?
The ingress template for s3 ingress is defined differently from the other seaweed component ingresses. A side effect of this is that when helm runs it generates the warning:
`coalesce.go:289: warning: destination for seaweedfs.s3.ingress.annotations is a table. Ignoring non-table value ([])`


# How are we solving the problem?
Align s3 ingress with the other components


# How is the PR tested?
tested in fork. ingress is created correctly and without warning.


# Checks
- [na] I have added unit tests if possible.
- [na] I will add related wiki document changes and link to this PR after merging.
